### PR TITLE
Call sql_executor with user and repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bit.io simple pipeline
 
-A simple bit.io pipeline example using scripts and the UNIX cron scheduler. 
+A simple bit.io pipeline example using scripts and the UNIX cron scheduler.
 
 ## Scope
 
-This repo is intended to provide a simple pipeline example for getting started with programmtic data ingestion and updates in bit.io. To keep the repo simple, many best practices such as logging, configuration files, and a more robust orchestration/scheduling framework are omitted. 
+This repo is intended to provide a simple pipeline example for getting started with programmtic data ingestion and updates in bit.io. To keep the repo simple, many best practices such as logging, configuration files, and a more robust orchestration/scheduling framework are omitted.
 
 ## Setup
 
@@ -61,5 +61,4 @@ The transformation functions are defined in `transform.py`. If you want to run t
 
 Once data has been extracted, transformed, and loaded, we sometimes want to create derived tables within the database. This script takes one argument, a path to a SQL script to run on bit.io. For example, to create the derived California COVID data table, the script is called as follows:
 
-`python sql_executor.py ca_covid_data.sql`
-
+`python sql_executor.py ca_covid_data.sql bitdotio simple_pipeline`

--- a/scheduled_run.sh
+++ b/scheduled_run.sh
@@ -6,4 +6,4 @@ cd simple_pipeline
 # python main.py -local_source -name acs_population_counties acs_5yr_population_data.csv bitdotio/simple_pipeline.population_counties
 python main.py -name nyt_cases_counties 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv' bitdotio/simple_pipeline.cases_counties
 python main.py -name cdc_vaccines_counties 'https://data.cdc.gov/api/views/8xkx-amqh/rows.csv?accessType=DOWNLOAD' bitdotio/simple_pipeline.vaccinations_counties
-python sql_executor.py ca_covid_data.sql
+python sql_executor.py ca_covid_data.sql bitdotio simple_pipeline


### PR DESCRIPTION
The invocation of `sql_executor.py` fails, because username and reponame need to be provided. Fixed this in the README descrition and in the `scheduled_run.sh` script.